### PR TITLE
Gate unconditional USE OMP_LIB on the !$ Fortran-OpenMP sentinel

### DIFF
--- a/get.Mumps
+++ b/get.Mumps
@@ -66,4 +66,10 @@ patch -p0 < mumps_mpi.patch
 mv MUMPS/libseq/mpi.h MUMPS/libseq/mumps_mpi.h
 
 echo " "
+echo "Apply a patch to gate USE OMP_LIB on the !\$ Fortran-OpenMP sentinel."
+echo " "
+
+patch -p0 < mumps_omp.patch
+
+echo " "
 echo "Verify that there are no error message in the output above."

--- a/mumps_omp.patch
+++ b/mumps_omp.patch
@@ -1,0 +1,192 @@
+diff -ur MUMPS_5.8.2/src/cfac_b.F MUMPS/src/cfac_b.F
+--- MUMPS_5.8.2/src/cfac_b.F	2026-01-12 16:17:29.000000000 +0100
++++ MUMPS/src/cfac_b.F	2026-05-15 15:44:17.500042616 +0200
+@@ -35,7 +35,7 @@
+      &                     , CMUMPS_BUF_DEALL_MAX_ARRAY
+       USE CMUMPS_FAC_S_IS_POINTERS_M, ONLY : CMUMPS_S_IS_POINTERS_T
+       USE MUMPS_PIVNUL_MOD, ONLY : PIVNUL_LIST_STRUCT_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE CMUMPS_TPS_M
+       USE CMUMPS_FAC_OMP_M
+diff -ur MUMPS_5.8.2/src/cfac_compact_factors_m.F MUMPS/src/cfac_compact_factors_m.F
+--- MUMPS_5.8.2/src/cfac_compact_factors_m.F	2026-01-12 16:17:31.000000000 +0100
++++ MUMPS/src/cfac_compact_factors_m.F	2026-05-15 15:44:17.501042624 +0200
+@@ -19,7 +19,7 @@
+      &      WK_USER_PROVIDED, S, KEEP, KEEP8, INFO, MYID, ICNTL,
+      &      PROK, MP, CMUMPS_LBUFR_BYTES8, CMUMPS_LBUF8, 
+      &      LIWK, LIWK8 )
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE CMUMPS_DYNAMIC_MEMORY_M, ONLY : CMUMPS_DM_FREE_S_WK
+ C
+ C Purpose
+diff -ur MUMPS_5.8.2/src/cfac_par_m.F MUMPS/src/cfac_par_m.F
+--- MUMPS_5.8.2/src/cfac_par_m.F	2026-01-12 16:17:30.000000000 +0100
++++ MUMPS/src/cfac_par_m.F	2026-05-15 15:44:17.502042632 +0200
+@@ -47,7 +47,7 @@
+       USE CMUMPS_FAC2_LDLT_M
+       USE CMUMPS_FAC1_LU_M
+       USE CMUMPS_FAC2_LU_M
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE CMUMPS_TPS_M
+       USE MUMPS_INTR_TYPES, ONLY : MUMPS_ROOT_STRUC
+diff -ur MUMPS_5.8.2/src/csol_omp_m.F MUMPS/src/csol_omp_m.F
+--- MUMPS_5.8.2/src/csol_omp_m.F	2026-01-12 16:17:29.000000000 +0100
++++ MUMPS/src/csol_omp_m.F	2026-05-15 15:44:17.504042647 +0200
+@@ -305,7 +305,7 @@
+      &  PERM_L0_OMP, PTR_LEAFS_L0_OMP, L0_OMP_MAPPING, LL0_OMP_MAPPING,
+      &  L0_OMP_FACTORS, LL0_OMP_FACTORS )
+       USE CMUMPS_INTR_TYPES, ONLY : CMUMPS_L0OMPFAC_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       IMPLICIT NONE
+       INTEGER, INTENT( in ) :: N, MTYPE, NRHS, SLAVEF, LIW
+       INTEGER, INTENT( in ) :: IW(LIW)
+diff -ur MUMPS_5.8.2/src/dfac_b.F MUMPS/src/dfac_b.F
+--- MUMPS_5.8.2/src/dfac_b.F	2026-01-12 16:17:28.000000000 +0100
++++ MUMPS/src/dfac_b.F	2026-05-15 15:44:17.505042655 +0200
+@@ -35,7 +35,7 @@
+      &                     , DMUMPS_BUF_DEALL_MAX_ARRAY
+       USE DMUMPS_FAC_S_IS_POINTERS_M, ONLY : DMUMPS_S_IS_POINTERS_T
+       USE MUMPS_PIVNUL_MOD, ONLY : PIVNUL_LIST_STRUCT_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE DMUMPS_TPS_M
+       USE DMUMPS_FAC_OMP_M
+diff -ur MUMPS_5.8.2/src/dfac_compact_factors_m.F MUMPS/src/dfac_compact_factors_m.F
+--- MUMPS_5.8.2/src/dfac_compact_factors_m.F	2026-01-12 16:17:31.000000000 +0100
++++ MUMPS/src/dfac_compact_factors_m.F	2026-05-15 15:44:17.507042671 +0200
+@@ -19,7 +19,7 @@
+      &      WK_USER_PROVIDED, S, KEEP, KEEP8, INFO, MYID, ICNTL,
+      &      PROK, MP, DMUMPS_LBUFR_BYTES8, DMUMPS_LBUF8, 
+      &      LIWK, LIWK8 )
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE DMUMPS_DYNAMIC_MEMORY_M, ONLY : DMUMPS_DM_FREE_S_WK
+ C
+ C Purpose
+diff -ur MUMPS_5.8.2/src/dfac_par_m.F MUMPS/src/dfac_par_m.F
+--- MUMPS_5.8.2/src/dfac_par_m.F	2026-01-12 16:17:29.000000000 +0100
++++ MUMPS/src/dfac_par_m.F	2026-05-15 15:44:17.509042686 +0200
+@@ -47,7 +47,7 @@
+       USE DMUMPS_FAC2_LDLT_M
+       USE DMUMPS_FAC1_LU_M
+       USE DMUMPS_FAC2_LU_M
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE DMUMPS_TPS_M
+       USE MUMPS_INTR_TYPES, ONLY : MUMPS_ROOT_STRUC
+diff -ur MUMPS_5.8.2/src/dsol_omp_m.F MUMPS/src/dsol_omp_m.F
+--- MUMPS_5.8.2/src/dsol_omp_m.F	2026-01-12 16:17:28.000000000 +0100
++++ MUMPS/src/dsol_omp_m.F	2026-05-15 15:44:17.510042694 +0200
+@@ -305,7 +305,7 @@
+      &  PERM_L0_OMP, PTR_LEAFS_L0_OMP, L0_OMP_MAPPING, LL0_OMP_MAPPING,
+      &  L0_OMP_FACTORS, LL0_OMP_FACTORS )
+       USE DMUMPS_INTR_TYPES, ONLY : DMUMPS_L0OMPFAC_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       IMPLICIT NONE
+       INTEGER, INTENT( in ) :: N, MTYPE, NRHS, SLAVEF, LIW
+       INTEGER, INTENT( in ) :: IW(LIW)
+diff -ur MUMPS_5.8.2/src/sfac_b.F MUMPS/src/sfac_b.F
+--- MUMPS_5.8.2/src/sfac_b.F	2026-01-12 16:17:28.000000000 +0100
++++ MUMPS/src/sfac_b.F	2026-05-15 15:44:17.511042701 +0200
+@@ -35,7 +35,7 @@
+      &                     , SMUMPS_BUF_DEALL_MAX_ARRAY
+       USE SMUMPS_FAC_S_IS_POINTERS_M, ONLY : SMUMPS_S_IS_POINTERS_T
+       USE MUMPS_PIVNUL_MOD, ONLY : PIVNUL_LIST_STRUCT_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE SMUMPS_TPS_M
+       USE SMUMPS_FAC_OMP_M
+diff -ur MUMPS_5.8.2/src/sfac_compact_factors_m.F MUMPS/src/sfac_compact_factors_m.F
+--- MUMPS_5.8.2/src/sfac_compact_factors_m.F	2026-01-12 16:17:31.000000000 +0100
++++ MUMPS/src/sfac_compact_factors_m.F	2026-05-15 15:44:17.512042709 +0200
+@@ -19,7 +19,7 @@
+      &      WK_USER_PROVIDED, S, KEEP, KEEP8, INFO, MYID, ICNTL,
+      &      PROK, MP, SMUMPS_LBUFR_BYTES8, SMUMPS_LBUF8, 
+      &      LIWK, LIWK8 )
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE SMUMPS_DYNAMIC_MEMORY_M, ONLY : SMUMPS_DM_FREE_S_WK
+ C
+ C Purpose
+diff -ur MUMPS_5.8.2/src/sfac_par_m.F MUMPS/src/sfac_par_m.F
+--- MUMPS_5.8.2/src/sfac_par_m.F	2026-01-12 16:17:28.000000000 +0100
++++ MUMPS/src/sfac_par_m.F	2026-05-15 15:44:17.513042717 +0200
+@@ -47,7 +47,7 @@
+       USE SMUMPS_FAC2_LDLT_M
+       USE SMUMPS_FAC1_LU_M
+       USE SMUMPS_FAC2_LU_M
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE SMUMPS_TPS_M
+       USE MUMPS_INTR_TYPES, ONLY : MUMPS_ROOT_STRUC
+diff -ur MUMPS_5.8.2/src/ssol_omp_m.F MUMPS/src/ssol_omp_m.F
+--- MUMPS_5.8.2/src/ssol_omp_m.F	2026-01-12 16:17:27.000000000 +0100
++++ MUMPS/src/ssol_omp_m.F	2026-05-15 15:44:17.515042732 +0200
+@@ -305,7 +305,7 @@
+      &  PERM_L0_OMP, PTR_LEAFS_L0_OMP, L0_OMP_MAPPING, LL0_OMP_MAPPING,
+      &  L0_OMP_FACTORS, LL0_OMP_FACTORS )
+       USE SMUMPS_INTR_TYPES, ONLY : SMUMPS_L0OMPFAC_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       IMPLICIT NONE
+       INTEGER, INTENT( in ) :: N, MTYPE, NRHS, SLAVEF, LIW
+       INTEGER, INTENT( in ) :: IW(LIW)
+diff -ur MUMPS_5.8.2/src/zfac_b.F MUMPS/src/zfac_b.F
+--- MUMPS_5.8.2/src/zfac_b.F	2026-01-12 16:17:30.000000000 +0100
++++ MUMPS/src/zfac_b.F	2026-05-15 15:44:17.516042740 +0200
+@@ -35,7 +35,7 @@
+      &                     , ZMUMPS_BUF_DEALL_MAX_ARRAY
+       USE ZMUMPS_FAC_S_IS_POINTERS_M, ONLY : ZMUMPS_S_IS_POINTERS_T
+       USE MUMPS_PIVNUL_MOD, ONLY : PIVNUL_LIST_STRUCT_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE ZMUMPS_TPS_M
+       USE ZMUMPS_FAC_OMP_M
+diff -ur MUMPS_5.8.2/src/zfac_compact_factors_m.F MUMPS/src/zfac_compact_factors_m.F
+--- MUMPS_5.8.2/src/zfac_compact_factors_m.F	2026-01-12 16:17:31.000000000 +0100
++++ MUMPS/src/zfac_compact_factors_m.F	2026-05-15 15:44:17.517042748 +0200
+@@ -19,7 +19,7 @@
+      &      WK_USER_PROVIDED, S, KEEP, KEEP8, INFO, MYID, ICNTL,
+      &      PROK, MP, ZMUMPS_LBUFR_BYTES8, ZMUMPS_LBUF8, 
+      &      LIWK, LIWK8 )
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE ZMUMPS_DYNAMIC_MEMORY_M, ONLY : ZMUMPS_DM_FREE_S_WK
+ C
+ C Purpose
+diff -ur MUMPS_5.8.2/src/zfac_par_m.F MUMPS/src/zfac_par_m.F
+--- MUMPS_5.8.2/src/zfac_par_m.F	2026-01-12 16:17:30.000000000 +0100
++++ MUMPS/src/zfac_par_m.F	2026-05-15 15:44:17.518042755 +0200
+@@ -47,7 +47,7 @@
+       USE ZMUMPS_FAC2_LDLT_M
+       USE ZMUMPS_FAC1_LU_M
+       USE ZMUMPS_FAC2_LU_M
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       USE MUMPS_TPS_M
+       USE ZMUMPS_TPS_M
+       USE MUMPS_INTR_TYPES, ONLY : MUMPS_ROOT_STRUC
+diff -ur MUMPS_5.8.2/src/zsol_omp_m.F MUMPS/src/zsol_omp_m.F
+--- MUMPS_5.8.2/src/zsol_omp_m.F	2026-01-12 16:17:30.000000000 +0100
++++ MUMPS/src/zsol_omp_m.F	2026-05-15 15:44:17.519042763 +0200
+@@ -305,7 +305,7 @@
+      &  PERM_L0_OMP, PTR_LEAFS_L0_OMP, L0_OMP_MAPPING, LL0_OMP_MAPPING,
+      &  L0_OMP_FACTORS, LL0_OMP_FACTORS )
+       USE ZMUMPS_INTR_TYPES, ONLY : ZMUMPS_L0OMPFAC_T
+-      USE OMP_LIB
++!$      USE OMP_LIB
+       IMPLICIT NONE
+       INTEGER, INTENT( in ) :: N, MTYPE, NRHS, SLAVEF, LIW
+       INTEGER, INTENT( in ) :: IW(LIW)


### PR DESCRIPTION
> **Note**: investigation by Claude Code (Opus 4.7).

## Problem

16 files in MUMPS 5.8.2 (and earlier) have an **unconditional** `USE OMP_LIB`, while ~158 other OpenMP references in those same files use the `!$` Fortran-OpenMP-conditional-compilation sentinel.  This is an internal inconsistency in MUMPS itself, not in ThirdParty-Mumps.

When building MUMPS without OpenMP support (e.g. for targets that lack it like `wasm32-emscripten`), the unconditional USE causes the build to fail with:

```
error: Cannot parse module file for module 'omp_lib': Source file 'omp_lib.mod' was not found
```

The 16 files all have `_omp_m`, `_par_m`, `_compact_factors_m`, `_b` suffixes — coverage is uniform across all four precisions (`s/d/c/z`), so this looks like a copy-paste oversight that propagated through the codebase.

## Fix

`mumps_omp.patch` gates each of the 16 `USE OMP_LIB` lines with `!$` at column 1, mirroring the **existing convention in those same files** (e.g. `dsol_omp_m.F` already has `!$      USE OMP_LIB` at line 33 — this patch just makes line 308 match).

```diff
       USE MUMPS_PIVNUL_MOD, ONLY : PIVNUL_LIST_STRUCT_T
-      USE OMP_LIB
+!$      USE OMP_LIB
       USE MUMPS_TPS_M
```

Total: 16 single-line edits across `src/{c,d,s,z}{fac_b,fac_compact_factors_m,fac_par_m,sol_omp_m}.F` (plus `{c,d,s,z}fac_b.F`).

## Safety analysis

All 16 files have **zero unconditional `omp_*()` callsites** — every `OMP_GET_*`/`OMP_SET_*`/`CALL OMP_*` in them is already `!$`-gated.  So gating the `USE OMP_LIB` symmetrically is correct:

- **`-fopenmp` off**: both the USE and the callsites are comments → file compiles cleanly without `omp_lib.mod` ✓
- **`-fopenmp` on**: both are active → file behaves identically to before ✓

(I grepped for `^[[:space:]]+[A-Z_a-z]*\s*=?\s*OMP_GET|^[[:space:]]+CALL OMP_` excluding `!$` lines across all 16 files — zero hits.)

## Verification

Tested by:

1. Generating the patch against MUMPS 5.8.2.
2. Applying it via the modified `get.Mumps`.
3. Building MUMPS via this ThirdParty-Mumps + r-wasm/flang-wasm flang targeting `wasm32-unknown-emscripten`, with `--without-openmp` and an empty `omp_lib` include path.
4. Result: MUMPS builds cleanly (just the pre-existing implicit-interface warnings, no errors).
5. Downstream: IPOPT links and solves a 2-variable NLP correctly in node and the browser via casadi's wasm pipeline.

## Discovery context

Found while building [casadi](https://github.com/casadi/casadi) for `wasm32-emscripten` via `r-wasm/flang-wasm`'s flang. Casadi's wasm build chain has a local workaround (an `omp_lib` Fortran stub module on the `flang -I` path) that does the same job at the consumer side; this patch moves the fix to the right place (MUMPS source via ThirdParty-Mumps) so other consumers building MUMPS-without-OpenMP get it for free.

## Upstreaming further

The right ultimate home is MUMPS itself (CERFACS/INPT/ENS-Lyon/Inria/Bordeaux/Mumps Technologies), but that's a slower process. This patch in ThirdParty-Mumps unblocks Coin-OR downstreams immediately.
